### PR TITLE
Add support for multiple Docker tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ ifndef DOCKER_REPO
 $(error "DOCKER_REPO must be defined in the project's Makefile.")
 endif
 
-# DOCKER_TAG is the name of the tag used when building a Docker image.
-# The default tag of 'dev' can not be pushed to the registry.
-DOCKER_TAG ?= dev
+# DOCKER_TAGS is a space-separated list of tag names used when building a Docker
+# image. The list defaults to just 'dev'. Note that the 'dev' tag cannot be
+# pushed to the registry.
+DOCKER_TAGS ?= dev
 
 # DOCKER_BUILD_REQ is a space separated list of prerequisites needed to build
 # the Docker image.
@@ -15,15 +16,27 @@ DOCKER_BUILD_REQ +=
 # the "docker build" command.
 DOCKER_BUILD_ARGS +=
 
+################################################################################
+
+# _DOCKER_TAG_TOUCH_FILES is a list of touch files for tagging Docker builds.
+# The list is automatically generated from DOCKER_TAGS.
+_DOCKER_TAG_TOUCH_FILES := $(foreach TAG,$(DOCKER_TAGS),artifacts/docker/tag/$(TAG).touch)
+
+# _DOCKER_PUSH_TOUCH_FILES is a list of touch files for pushing Docker tags. The
+# list is automatically generated from DOCKER_TAGS.
+_DOCKER_PUSH_TOUCH_FILES := $(foreach TAG,$(DOCKER_TAGS),artifacts/docker/push/$(TAG).touch)
+
+################################################################################
+
 # docker --- Builds a docker image from the Dockerfile in the root of the
 # repository.
 .PHONY: docker
-docker: artifacts/docker/build-$(DOCKER_TAG).touch
+docker: $(_DOCKER_TAG_TOUCH_FILES)
 
 # docker-build --- Builds a docker image from the Dockerfile in the root of the
 # repository and pushes it to the registry.
 .PHONY: docker-push
-docker-push: artifacts/docker/push-$(DOCKER_TAG).touch
+docker-push: $(_DOCKER_PUSH_TOUCH_FILES)
 
 ################################################################################
 
@@ -35,24 +48,27 @@ docker-push: artifacts/docker/push-$(DOCKER_TAG).touch
 	@echo .makefiles > "$@"
 	@echo .git >> "$@"
 
-artifacts/docker/build-%.touch: Dockerfile .dockerignore $(DOCKER_BUILD_REQ)
+artifacts/docker/image-id: Dockerfile .dockerignore $(DOCKER_BUILD_REQ)
+	@mkdir -p "$(@D)"
+
 	docker build \
 		--pull \
-		--build-arg "VERSION=$(GIT_HASH_COMMITTISH)" \
-		--build-arg "TAG=$*" \
-		--tag "$(DOCKER_REPO):$*" \
+		--build-arg "VERSION=$(GIT_HEAD_COMMITTISH)" \
+		--iidfile "$@"
 		$(DOCKER_BUILD_ARGS) \
 		.
 
+artifacts/docker/tag/%.touch: artifacts/docker/image-id
+	docker tag "$(shell cat "$<")" "$(DOCKER_REPO):$*"
 	@mkdir -p "$(@D)"
 	@touch "$@"
 
-.PHONY: artifacts/docker/push-dev
-artifacts/docker/push-dev.touch:
+.PHONY: artifacts/docker/push/dev.touch
+artifacts/docker/push/dev.touch:
 	@echo "The 'dev' tag can not be pushed to the registry!"
 	@exit 1
 
-artifacts/docker/push-%.touch: artifacts/docker/build-%.touch
+artifacts/docker/push/%.touch: artifacts/docker/tag/%.touch
 	docker push "$(DOCKER_REPO):$*"
 	@mkdir -p "$(@D)"
 	@touch "$@"


### PR DESCRIPTION
This PR adds support for multiple Docker tags. 

- The list of tags will be specified via `DOCKER_TAGS`
- The restriction on pushing the `dev` tag will remain
- The build and tagging steps will be split into multiple make targets
- The `docker build` option `--iidfile` will be utilized to store the image ID for later tagging