### PR TITLE
Use `GIT_HEAD_SEMVER` for the `VERSION` build argument.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ artifacts/docker/image-id: Dockerfile .dockerignore $(DOCKER_BUILD_REQ)
 
 	docker build \
 		--pull \
-		--build-arg "VERSION=$(GIT_HEAD_COMMITTISH)" \
+		--build-arg "VERSION=$(GIT_HEAD_SEMVER)" \
 		--iidfile "$@" \
 		$(DOCKER_BUILD_ARGS) \
 		.


### PR DESCRIPTION
Blocked by https://github.com/make-files/lib-core/pull/6.
